### PR TITLE
Add type hints to prevent reflection (make compatible with GraalVM native image)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {ring/ring-core {:mvn/version "1.8.2"}}}


### PR DESCRIPTION
Hi! First off all - thank you for this amazing middleware, it saves me a weekends.

But I have some small issue with it - reflection calls in several places, 
that prevents compiling application to the native-image.

I have added type-hints and checked that everything is working in GraalVM.

Also added deps.edn as second project configuration file - it gives ability to use your library without publishing 
it to clojars - just use it with git coordinates like this:

```
ring-range-middleware {:git/url "https://github.com/patosai/ring-range-middleware"
                                          :git/sha "fc92eb85b12f30087ac62361d19d3e3258e91a0c"}
```

I think it would be nice contribution for your library also.

Look please at pull request and feel free to ask questions if something done in inconvenient way